### PR TITLE
Change token key from token to access_token

### DIFF
--- a/pusher_chatkit/pusher_chatkit.py
+++ b/pusher_chatkit/pusher_chatkit.py
@@ -56,7 +56,7 @@ class PusherChatKit(object):
 
         token = jwt.encode(claims, split_key[1])
 
-        return {"token": token.decode("utf-8"), "expires_in": 24 * 60 * 60}
+        return {"access_token": token.decode("utf-8"), "expires_in": 24 * 60 * 60}
 
     def authenticate_user(self, user_id):
         """


### PR DESCRIPTION
Current version of pusher client like javascipt and [swift](https://pusher.com/docs/chatkit/reference/swift#pctokenprovider-arguments) expect the JWT token in `access_token` instead of `token` key. So change it in generate token.